### PR TITLE
Add response formatting utility

### DIFF
--- a/src/lbshared/responses.py
+++ b/src/lbshared/responses.py
@@ -8,8 +8,7 @@ import traceback
 class DefaultDictWithKeyArg(dict):
     """Essentially a default dictionary, except it passes the name of the
     key to the __missing__ lambda."""
-    def __init__(self, default, **kwargs):
-        super(**kwargs)
+    def __init__(self, default):
         self.default = default
 
     def __missing__(self, key):
@@ -58,7 +57,9 @@ def get_response(itgs: LazyIntegrations, name: str, **replacements):
         )
         return f'[ERROR: unknown substitution "{key}"]'
 
-    format_dict = DefaultDictWithKeyArg(factory, **replacements)
+    format_dict = DefaultDictWithKeyArg(factory)
+    for k, v in replacements.items():
+        format_dict[k] = v
     return unformatted.format_map(format_dict)
 
 

--- a/src/lbshared/responses.py
+++ b/src/lbshared/responses.py
@@ -1,0 +1,78 @@
+"""A collection of convenience functions for formatting responses."""
+from collections import defaultdict
+from .lazy_integrations import LazyIntegrations
+from lblogging import Level
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+import traceback
+
+
+def get_response(itgs: LazyIntegrations, name: str, **replacements):
+    """Get the formatted response with the given name using the given
+    substitutions. Every substitution is formatted using str(), if replacements
+    is missing any keys the response expects the event will be logged but a
+    response will be returned. If replacements contains keys not expected
+    by the response they are simply ignored.
+
+    @param [LazyIntegrations] itgs The lazy integrations to use for connecting
+        to the database and/or logger. This will only use a read cursor on the
+        database.
+    @param [str] name The name of the response to format
+    @param [dict] replacements A map from the names of keys to substitute within
+      the response body to an object which will be stringified.
+    @return [str] The formatted response.
+    """
+    responses = Table('responses')
+    itgs.read_cursor.execute(
+        Query.from_(responses).select(responses.response_body)
+        .where(responses.name == Parameter('%s')).limit(1).get_sql(),
+        (name,)
+    )
+    row = itgs.read_cursor.fetchone()
+    if row is None:
+        itgs.logger.print(
+            Level.WARN,
+            'There was a request to format the response {} which is not a '
+            'response name for which a response format exists! '
+            'Stack trace:\n{}',
+            name, ''.join(traceback.format_stack())
+        )
+        return f'ERROR: Unknown response: "{name}"'
+    (unformatted,) = row
+
+    def factory(key):
+        itgs.logger.print(
+            Level.WARN,
+            'While formatting response {} there was a request to substitute {} '
+            'but the only known substitutions are {}',
+            name, key, ', '.join(replacements.keys())
+        )
+        return f'[ERROR: unknown substitution "{key}"]'
+
+    format_dict = defaultdict(factory)
+    return unformatted.format_map(format_dict)
+
+
+def get_letter_response(itgs: LazyIntegrations, base_name: str, **replacements):
+    """This is a helper method for formatting "letter responses", which are
+    responses which have a title and body and the same substitutions are used
+    for both. In practice some of the replacements for the body might look
+    silly in the title, but it doesn't hurt to expose them there.
+
+    This assumes that the response names are `f'{base_name}_title'` and
+    `f'{base_name}_body'` respectively.
+
+    @param [LazyIntegrations] itgs The lazy integrations to use for connecting
+        to the database and/or logger. This will only use a read cursor on the
+        database.
+    @param [str] base_name The base of the response names for the title and
+        body. Suffixed with _title and _body for the title and body
+        respectively.
+    @param [dict] replacements A dictionary where keys are the names of keys
+        in the response to substitute, as if by format_map.
+    @return [str, str] Two tuples; the first is the formatted title and the
+        second is the formatted body.
+    """
+    return (
+        get_response(itgs, base_name + '_title', **replacements),
+        get_response(itgs, base_name + '_body', **replacements)
+    )

--- a/src/lbshared/responses.py
+++ b/src/lbshared/responses.py
@@ -8,7 +8,8 @@ import traceback
 class DefaultDictWithKeyArg(dict):
     """Essentially a default dictionary, except it passes the name of the
     key to the __missing__ lambda."""
-    def __init__(self, default):
+    def __init__(self, default, **kwargs):
+        super(**kwargs)
         self.default = default
 
     def __missing__(self, key):
@@ -57,7 +58,7 @@ def get_response(itgs: LazyIntegrations, name: str, **replacements):
         )
         return f'[ERROR: unknown substitution "{key}"]'
 
-    format_dict = DefaultDictWithKeyArg(factory)
+    format_dict = DefaultDictWithKeyArg(factory, **replacements)
     return unformatted.format_map(format_dict)
 
 

--- a/src/lbshared/responses.py
+++ b/src/lbshared/responses.py
@@ -1,9 +1,18 @@
 """A collection of convenience functions for formatting responses."""
-from collections import defaultdict
 from .lazy_integrations import LazyIntegrations
 from lblogging import Level
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 import traceback
+
+
+class DefaultDictWithKeyArg(dict):
+    """Essentially a default dictionary, except it passes the name of the
+    key to the __missing__ lambda."""
+    def __init__(self, default):
+        self.default = default
+
+    def __missing__(self, key):
+        return self.default(key)
 
 
 def get_response(itgs: LazyIntegrations, name: str, **replacements):
@@ -48,7 +57,7 @@ def get_response(itgs: LazyIntegrations, name: str, **replacements):
         )
         return f'[ERROR: unknown substitution "{key}"]'
 
-    format_dict = defaultdict(factory)
+    format_dict = DefaultDictWithKeyArg(factory)
     return unformatted.format_map(format_dict)
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -26,7 +26,7 @@ class TestResponses(unittest.TestCase):
                     resps.response_body,
                     resps.description
                 ).insert(*[Parameter('%s') for _ in range(3)])
-                .returning(ress.id).get_sql(),
+                .returning(resps.id).get_sql(),
                 (
                     'my_response',
                     'I like to {foo} the {bar}',

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,60 @@
+"""Verifies that all the connections that can be created using the integrations
+module are able to service simple requests"""
+import unittest
+import sys
+import time
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+
+sys.path.append("../src")
+
+import lbshared.responses as responses  # noqa: E402
+from lbshared.lazy_integrations import LazyIntegrations  # noqa: E402
+
+
+class TestResponses(unittest.TestCase):
+    def test_missing(self):
+        with LazyIntegrations() as itgs:
+            res = responses.get_response(itgs, 'my_missing_key')
+            self.assertIsInstance(res, str)
+            self.assertIn('my_missing_key', res)
+
+    def test_existing(self):
+        responses = Table('responses')
+        with LazyIntegrations() as itgs:
+            itgs.write_cursor.execute(
+                Query.into(responses).columns(
+                    responses.name,
+                    responses.response_body,
+                    responses.description
+                ).insert(*[Parameter('%s') for _ in range(3)])
+                .returning(responses.id).get_sql(),
+                (
+                    'my_response',
+                    'I like to {foo} the {bar}',
+                    'Testing desc'
+                )
+            )
+            (respid,) = itgs.write_cursor.fetchone()
+            try:
+                itgs.write_conn.commit()
+                res: str = responses.get_response(itgs, 'my_response', foo='open', bar='door')
+                self.assertEqual(res, 'I like to open the door')
+
+                res: str = responses.get_response(itgs, 'my_response', foo='eat', buzz='bear')
+                self.assertIsInstance(res, str)
+                self.assertTrue(res.startswith('I like to eat the '), res)
+                # it's not important how we choose to format the error, but it
+                # needs the missing key or debugging will be a pain
+                self.assertIn('bar', res)
+            finally:
+                itgs.write_conn.rollback()
+                itgs.write_cursor.execute(
+                    Query.from_(responses).delete()
+                    .where(responses.id == Parameter('%s')),
+                    (respid,)
+                )
+                itgs.write_conn.commit()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -2,7 +2,6 @@
 module are able to service simple requests"""
 import unittest
 import sys
-import time
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 
 sys.path.append("../src")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -49,7 +49,8 @@ class TestResponses(unittest.TestCase):
                 itgs.write_conn.rollback()
                 itgs.write_cursor.execute(
                     Query.from_(responses).delete()
-                    .where(responses.id == Parameter('%s')),
+                    .where(responses.id == Parameter('%s'))
+                    .get_sql(),
                     (respid,)
                 )
                 itgs.write_conn.commit()

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -18,15 +18,15 @@ class TestResponses(unittest.TestCase):
             self.assertIn('my_missing_key', res)
 
     def test_existing(self):
-        responses = Table('responses')
+        resps = Table('responses')
         with LazyIntegrations() as itgs:
             itgs.write_cursor.execute(
-                Query.into(responses).columns(
-                    responses.name,
-                    responses.response_body,
-                    responses.description
+                Query.into(resps).columns(
+                    resps.name,
+                    resps.response_body,
+                    resps.description
                 ).insert(*[Parameter('%s') for _ in range(3)])
-                .returning(responses.id).get_sql(),
+                .returning(ress.id).get_sql(),
                 (
                     'my_response',
                     'I like to {foo} the {bar}',
@@ -48,8 +48,8 @@ class TestResponses(unittest.TestCase):
             finally:
                 itgs.write_conn.rollback()
                 itgs.write_cursor.execute(
-                    Query.from_(responses).delete()
-                    .where(responses.id == Parameter('%s'))
+                    Query.from_(resps).delete()
+                    .where(resps.id == Parameter('%s'))
                     .get_sql(),
                     (respid,)
                 )


### PR DESCRIPTION
This adds two convenience functions for formatting responses - one for getting a single response and one for getting two responses which are in the standard title/body split. These support a different format that LoansBotv1 in that where before a response might look like

```Here is my information on /u/<user1>:```

Now it looks like

```Here is my information on /u/{user1}:```