### PR TITLE
Add fn to convert number-param SQL to order

### DIFF
--- a/src/lbshared/queries.py
+++ b/src/lbshared/queries.py
@@ -1,0 +1,59 @@
+"""Convenience functions for working with SQL queries"""
+import pytypeutils as tus
+import re
+
+
+def convert_numbered_args(query, args):
+    """Converts a query which was written using numbered args to the
+    corresponding query using ordered arguments, making the required
+    adjustments to the args array.
+
+    This is best illustrated by example:
+
+        (query, args) = convert_numbered_args(
+            'SELECT * FROM foo WHERE bar = $2 AND baz > $1'
+            (15, 'barval')
+        )
+        print(query) # 'SELECT * FROM foo WHERE bar = %s AND baz > %s'
+        print(args) # ('barval', 15)
+
+    This is extremely convenient if the order in which the query parameters are
+    selected may differ from the order they appear in the query. This most
+    commonly happens if a query may join with different tables depending on the
+    arguments.
+
+    This will assume it is given valid SQL and will make no attempts to verify
+    the SQL. If there are gaps in the numbered parameters, or they do not start
+    at 0, the behavior of this function is explicitly undefined.
+
+    This does support numbered parameters which have duplicates, so for example
+
+        (query, args) = convert_numbered_args(
+            'SELECT * FROM foo WHERE bar = $1 AND baz > $1',
+            (5,)
+        )
+        print(query) # 'SELECT * FROM foo WHERE bar = %s AND baz > %s'
+        print(args) # (5, 5)
+
+    Arguments:
+        query (str): A SQL query string using numbered parameters.
+        args (list, tuple): The list of arguments to pass to theq uery.
+
+    Returns:
+        query (str): The same SQL query using ordered parameters.
+        args (tuple): The list of arguments to pass to the query.
+    """
+    tus.check(query=(query, str), args=(args, (list, tuple)))
+
+    if not args:
+        return (query, tuple())
+
+    result_args = []
+    pattern = r'\$(\d+)'
+
+    for match in re.finditer(pattern, query):
+        result_args.append(args[int(match.group(1)) - 1])
+
+    result_query = re.sub(pattern, '%s', query)
+
+    return (result_query, tuple(result_args))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,7 +1,6 @@
 """Test the queries module"""
 import unittest
 import sys
-import secrets
 
 sys.path.append("../src")
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,59 @@
+"""Test the queries module"""
+import unittest
+import sys
+import secrets
+
+sys.path.append("../src")
+
+import lbshared.queries  # noqa: E402
+
+
+class TestQueries(unittest.TestCase):
+    def test_convert_numbered_args_no_args(self):
+        (query, args) = lbshared.queries.convert_numbered_args(
+            'SELECT * FROM foo',
+            []
+        )
+        self.assertEqual(query, 'SELECT * FROM foo')
+        self.assertIsInstance(args, tuple)
+        self.assertEqual(len(args), 0)
+
+    def test_convert_numbered_args_one_arg(self):
+        (query, args) = lbshared.queries.convert_numbered_args(
+            'SELECT * FROM foo WHERE id = $1',
+            ('baz',)
+        )
+        self.assertEqual(query, 'SELECT * FROM foo WHERE id = %s')
+        self.assertEqual(args, ('baz',))
+
+    def test_convert_numbered_args_two_args(self):
+        (query, args) = lbshared.queries.convert_numbered_args(
+            'SELECT * FROM foo JOIN bar ON bar.id = $2 WHERE foo.id = $1',
+            (3, 7)
+        )
+        self.assertEqual(query, 'SELECT * FROM foo JOIN bar ON bar.id = %s WHERE foo.id = %s')
+        self.assertEqual(args, (7, 3))
+
+    def test_convert_numbered_args_duplicated_arg(self):
+        (query, args) = lbshared.queries.convert_numbered_args(
+            'SELECT * FROM foo WHERE ($1 IS NULL OR foo.id > $1)',
+            (123,)
+        )
+        self.assertEqual(query, 'SELECT * FROM foo WHERE (%s IS NULL OR foo.id > %s)')
+        self.assertEqual(args, (123, 123))
+
+    def test_convert_numbered_args_duplicate_and_multiple(self):
+        # This query doesn't make sense but that's not the point
+        (query, args) = lbshared.queries.convert_numbered_args(
+            'SELECT * FROM foo WHERE ($2 IS NULL OR foo.id > $1) AND ($1 IS NULL OR foo.id < $2)',
+            (123, 76)
+        )
+        self.assertEqual(
+            query,
+            'SELECT * FROM foo WHERE (%s IS NULL OR foo.id > %s) AND (%s IS NULL OR foo.id < %s)'
+        )
+        self.assertEqual(args, (76, 123, 123, 76))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is just very convenient all the time, isn't particularly
complicated, and usually results in cleaner/more reliable
SQL generation code